### PR TITLE
machine_architecture as variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 cloudwatch_agent_path: "/opt/aws/amazon-cloudwatch-agent"
+machine_architecture: "amd64"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: install amazon cloudwatch agent
   become: yes
   apt:
-    deb: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+    deb: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/{{ machine_architecture }}/latest/amazon-cloudwatch-agent.deb
 
 - set_fact:
     cloudwatch_conf: "{{ playbook_dir }}/templates/cloudwatch/config.json"


### PR DESCRIPTION
Cloudwatch agent deb for ubuntu can differ according to the machine architecture ("amd64", "arm64", etc.).

This introduces a variable `machine_architecture` to define which architecture consider.